### PR TITLE
Fix debug50 stalls and glibc step-into on Codespaces

### DIFF
--- a/python-clients/cs50vsix-client/debug50/__main__.py
+++ b/python-clients/cs50vsix-client/debug50/__main__.py
@@ -68,8 +68,8 @@ LAUNCH_CONFIG = {
                     "text": "-interpreter-exec console \"skip -gfi **/glibc*/**/*.c\""
                 },
                 {
-                    "description": "Skip glibc internals by source dir (matches paths like ./stdio-common/printf.c)",
-                    "text": "-interpreter-exec console \"skip -rfi /(stdio-common|stdio|libio|string|sysdeps|nptl|malloc|stdlib|io|math|time|ctype|posix|misc|elf|signal|wcsmbs|wctype|locale|dirent|inet|setjmp|debug|dlfcn|grp|iconv|nss|pwd|resolv|shadow|socket|sunrpc|sysvipc|termios)/\"",
+                    "description": "Skip glibc internals by source dir (anchored to recorded relative paths like ./stdio-common/printf.c so user code under /workspaces/... isn't matched)",
+                    "text": "-interpreter-exec console \"skip -rfi ^(\\\\./)?(stdio-common|stdio|libio|string|sysdeps|nptl|malloc|stdlib|io|math|time|ctype|posix|misc|elf|signal|wcsmbs|wctype|locale|dirent|inet|setjmp|debug|dlfcn|grp|iconv|nss|pwd|resolv|shadow|socket|sunrpc|sysvipc|termios)/\"",
                     "ignoreFailures": True
                 },
                 {

--- a/python-clients/cs50vsix-client/debug50/__main__.py
+++ b/python-clients/cs50vsix-client/debug50/__main__.py
@@ -45,7 +45,7 @@ LAUNCH_CONFIG = {
             "MIDebuggerPath": "gdb",
 
             # https://github.com/microsoft/vscode-cpptools/issues/3298
-            "miDebuggerArgs": "-q -ex quit; wait() { fg >/dev/null; }; /bin/gdb -q --interpreter=mi",
+            "miDebuggerArgs": "-q -ex quit; wait() { fg >/dev/null; }; env -u DEBUGINFOD_URLS /bin/gdb -q --interpreter=mi",
 
             "setupCommands": [
                 {
@@ -54,8 +54,28 @@ LAUNCH_CONFIG = {
                     "ignoreFailures": True
                 },
                 {
+                    "description": "Disable debuginfod (avoids stalls in Codespaces)",
+                    "text": "-interpreter-exec console \"set debuginfod enabled off\"",
+                    "ignoreFailures": True
+                },
+                {
+                    "description": "Clear debuginfod URLs (belt-and-suspenders for vDSO lookups)",
+                    "text": "-interpreter-exec console \"set debuginfod urls\"",
+                    "ignoreFailures": True
+                },
+                {
                     "description": "Skip glibc",
                     "text": "-interpreter-exec console \"skip -gfi **/glibc*/**/*.c\""
+                },
+                {
+                    "description": "Skip glibc internals by source dir (matches paths like ./stdio-common/printf.c)",
+                    "text": "-interpreter-exec console \"skip -rfi /(stdio-common|stdio|libio|string|sysdeps|nptl|malloc|stdlib|io|math|time|ctype|posix|misc|elf|signal|wcsmbs|wctype|locale|dirent|inet|setjmp|debug|dlfcn|grp|iconv|nss|pwd|resolv|shadow|socket|sunrpc|sysvipc|termios)/\"",
+                    "ignoreFailures": True
+                },
+                {
+                    "description": "Skip glibc internals by symbol name (catches __vfprintf_internal, __GI_*, __printf_chk, etc.)",
+                    "text": "-interpreter-exec console \"skip -rfunction ^(__|_IO_)\"",
+                    "ignoreFailures": True
                 }
             ]
         },


### PR DESCRIPTION
## Summary

Two debugger issues surfaced on Codespaces:

1. **Debug sessions stalled for minutes on startup.** GDB's debuginfod client was attempting to fetch debug info from the network for every shared library (vDSO, libcrypt, libcs50, libm, libc) and hitting the 90s per-library timeout. Mitigated by stripping `DEBUGINFOD_URLS` from gdb's env in `miDebuggerArgs`, plus belt-and-suspenders `setupCommands` that disable debuginfod and clear its URL list.
2. **Step Into on standard library calls raised `Could not load source '...': 'SourceRequest' not supported`.** The Codespace image carries glibc debug info but not sources, and `cppdbg` does not implement the DAP `source` request. The existing skip pattern only matched paths containing `glibc`, so it missed glibc's recorded relative paths like `./stdio-common/printf.c`. Added a broader file regex covering glibc's subdirectories and a symbol regex skipping `__*` / `_IO_*` internal helpers.

## Test plan

- [ ] Reinstall the updated `cs50vsix-client` in a Codespace
- [ ] Run `debug50 ./hello` on a C program with a breakpoint — debugger reaches the breakpoint promptly, no "Downloading separate debug info..." stalls
- [ ] In the Debug Console, run \`-exec info skip\` and confirm the glibc file/function skip rules are listed
- [ ] Step Into a \`printf(...)\` call — debugger steps over it cleanly without surfacing a "SourceRequest not supported" error
- [ ] Set a breakpoint and step through a Python script via \`debug50 python hello.py\` — Python flow still works
- [ ] Launch a Java debug session via \`debug50 java HelloWorld\` — Java flow still works